### PR TITLE
Update THIRD-PARTY-NOTICES(converters)

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -122,13 +122,4 @@ License: Apache License 2.0
 Homepage: https://central.sonatype.org/publish/publish-portal-maven/
 ================================================================================
 
-================================================================================
-Package: Git Commit Id Maven Plugin
- (git-commit-id-plugin)
-Version: 3.0.1
-License: GNU Lesser General Public License 3.0
-         (Inferred from project’s official repository)
-Homepage: https://github.com/git-commit-id/git-commit-id-maven-plugin
-================================================================================
-
 Full license texts and additional details for each of the above packages are available in the license/ directory of this repository. Please refer to those files or the original source of each package for complete legal terms and conditions.

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,134 @@
+THIRD-PARTY-NOTICES
+
+This project includes third-party packages that are distributed under various open-source licenses. Below is a list of packages and their associated licenses.
+
+================================================================================
+Package: Spring Boot, Spring Security & Spring Cloud
+ (spring-boot-starter-web, spring-boot-starter-security,
+  spring-boot-configuration-processor, spring-boot-maven-plugin,
+  spring-security-core, spring-security-web, spring-security-config,
+  spring-security-test, spring-cloud-starter-config)
+Version: Various (including Spring Boot Maven Plugin 3.2.3; other
+         component versions not specified in SBOM)
+License: Apache License 2.0 (Inferred from project’s official repositories)
+Homepage: https://spring.io/projects/spring-boot
+================================================================================
+
+================================================================================
+Package: SpringDoc OpenAPI
+ (springdoc-openapi-starter-webmvc-ui)
+Version: 2.5.0
+License: Apache License 2.0
+Homepage: https://springdoc.org/
+================================================================================
+
+================================================================================
+Package: MOSIP Kernel Libraries
+ (kernel-bom, kernel-core, kernel-auth-adapter, kernel-logger-logback)
+Version: 1.3.0-SNAPSHOT
+License: Mozilla Public License 2.0
+         (Inferred from project’s official repository)
+Homepage: https://github.com/mosip/commons
+================================================================================
+
+================================================================================
+Package: MOSIP Biometric Utilities
+ (biometrics-util)
+Version: 1.3.0-SNAPSHOT
+License: Mozilla Public License 2.0
+         (Inferred from project’s official repository)
+Homepage: https://github.com/mosip/commons
+================================================================================
+
+================================================================================
+Package: Jackson Dataformat XML
+ (jackson-dataformat-xml)
+Version: (Not specified in SBOM)
+License: Apache License 2.0
+         (Inferred from project’s official repository)
+Homepage: https://github.com/FasterXML/jackson-dataformat-xml
+================================================================================
+
+================================================================================
+Package: Jakarta Servlet API
+ (jakarta.servlet-api)
+Version: (Not specified in SBOM)
+License: Eclipse Public License 2.0
+         (Inferred from project’s official repository)
+Homepage: https://jakarta.ee/specifications/servlet/
+================================================================================
+
+================================================================================
+Package: Vert.x Core
+ (vertx-core)
+Version: 3.9.13
+License: Apache License 2.0
+Homepage: https://vertx.io/
+================================================================================
+
+================================================================================
+Package: JAI ImageIO JPEG 2000
+ (jai-imageio-jpeg2000)
+Version: 1.3.0
+License: BSD 3-Clause No Nuclear License
+Homepage: https://github.com/jai-imageio/jai-imageio-core
+================================================================================
+
+================================================================================
+Package: Imgscalr
+ (imgscalr-lib)
+Version: 4.2
+License: Apache License 2.0
+Homepage: https://github.com/rkalla/imgscalr
+================================================================================
+
+================================================================================
+Package: Lombok
+ (org.projectlombok:lombok)
+Version: (Not specified in SBOM)
+License: MIT License
+         (Inferred from project’s official repository)
+Homepage: https://projectlombok.org/
+================================================================================
+
+================================================================================
+Package: JUnit Vintage Engine
+ (junit-vintage-engine)
+Version: (Not specified in SBOM)
+License: Eclipse Public License 2.0
+         (Inferred from project’s official repository)
+Homepage: https://junit.org/junit5/
+================================================================================
+
+================================================================================
+Package: Apache Maven Build Plugins
+ (maven-compiler-plugin, maven-surefire-plugin, maven-gpg-plugin,
+  maven-javadoc-plugin, maven-source-plugin)
+Version: Various (including:
+         - maven-compiler-plugin: 3.11.0
+         - maven-surefire-plugin: 2.22.0
+         - maven-gpg-plugin: 3.2.3
+         - maven-javadoc-plugin: 3.2.0
+         - maven-source-plugin: 3.3.1)
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins/
+================================================================================
+
+================================================================================
+Package: Central Publishing Maven Plugin
+ (central-publishing-maven-plugin)
+Version: 0.7.0
+License: Apache License 2.0
+Homepage: https://central.sonatype.org/publish/publish-portal-maven/
+================================================================================
+
+================================================================================
+Package: Git Commit Id Maven Plugin
+ (git-commit-id-plugin)
+Version: 3.0.1
+License: GNU Lesser General Public License 3.0
+         (Inferred from project’s official repository)
+Homepage: https://github.com/git-commit-id/git-commit-id-maven-plugin
+================================================================================
+
+Full license texts and additional details for each of the above packages are available in the license/ directory of this repository. Please refer to those files or the original source of each package for complete legal terms and conditions.


### PR DESCRIPTION
Removed JaCoCo Maven Plugin and SonarQube Scanner entries from third-party notices.